### PR TITLE
fix: typo on postgresql section in getting started

### DIFF
--- a/docs/guide/golang-orm.md
+++ b/docs/guide/golang-orm.md
@@ -131,7 +131,7 @@ import (
 )
 
 // Using pgdriver (recommended)
-sqldb := sql.NewDB(pgdriver.NewConnector(
+sqldb := sql.OpenDB(pgdriver.NewConnector(
     pgdriver.WithDSN("postgres://user:password@localhost:5432/dbname?sslmode=disable"),
 ))
 db := bun.NewDB(sqldb, pgdialect.New())


### PR DESCRIPTION
As far as I know, the `database/sql` package does not have a `NewDB` function. I think the intended function is `OpenDB`. This PR fixes that issue.